### PR TITLE
Fixed bug associated appending to the DTC section (#1444)

### DIFF
--- a/src/runtime_src/tools/xclbin/XclBin.cxx
+++ b/src/runtime_src/tools/xclbin/XclBin.cxx
@@ -1039,7 +1039,8 @@ XclBin::appendSections(ParameterSectionData &_PSD)
 
       // Add DTC exception. Only for 2019.1
       if (eKind == DTC) {
-        pSection = pTempSection;
+        pSection = Section::createSectionObjectOfKind(eKind);
+        addSection(pSection);
       } else {
         std::string errMsg = XUtil::format("ERROR: Section '%s' doesn't exists for JSON key '%s'.  Must have an existing section in order to append.", pTempSection->getSectionKindAsString().c_str(), sectionName.c_str());
         throw std::runtime_error(errMsg);


### PR DESCRIPTION
Issue: When appending the DTC section, the section wasn't beening added to the output xclbin archive if it didn't exist.